### PR TITLE
added max-scaling-factor parameter to avoid unrealistic results

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ BiasAdjustCXX                        \
     --scen input_data/scenario.nc    \ # time series to adjust
     -v tas                           \ # variable to adjust
     -m quantile_delta_mapping        \ # adjustment method
-    -k "+"                           \ # kind of qdjustment ("+" == "add" and "*" == "mult")
+    -k "+"                           \ # kind of adjustment ("+" == "add" and "*" == "mult")
     -q 100                             # quantiles to respect
 ```
 
@@ -101,6 +101,7 @@ BiasAdjustCXX -h
 
 - Installed NetCDF4 C++ Library ([How to install NetCDF4 for C++](https://docs.geoserver.org/stable/en/user/extensions/netcdf-out/nc4.html))
 - Climate Data Operators ([How to install cdo](https://www.isimip.org/protocol/preparing-simulation-files/cdo-help/))
+- CMake v3.10+ ([How to install CMake](https://cmake.org/install/))
 
 ### Optional for working examples in notebook (`examples.ipynb`)
 

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "// select time series\n",
+    "// select one time series from the data set (i. e. the time series of one location/grid cell)\n",
     "ds_obs.get_timeseries(v_obs_one_loc, 0, 0);\n",
     "ds_simh.get_timeseries(v_simh_one_loc, 0, 0);\n",
     "ds_simp.get_timeseries(v_simp_one_loc, 0, 0);"
@@ -153,7 +153,7 @@
    "outputs": [],
    "source": [
     "// select metotds \n",
-    "CM_Func_ptr_scaling apply_adjustment_ls = CMethods::get_cmethod_scaling(\"linear_scaling\");\n",
+    "CM_Func_ptr_scaling_add apply_adjustment_ls_add = CMethods::get_cmethod_scaling_add(\"linear_scaling\");\n",
     "CM_Func_ptr_distribution apply_adjustment_qdm = CMethods::get_cmethod_distribution(\"quantile_delta_mapping\");"
    ]
   },
@@ -167,42 +167,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "31e5a36d-2648-47d0-af40-3d7fd2c7b136",
    "metadata": {},
    "outputs": [],
    "source": [
-    "// apply linear scaling\n",
-    "apply_adjustment_ls(\n",
-    "    v_ls_result, \n",
-    "    v_obs_one_loc, \n",
-    "    v_simh_one_loc, \n",
-    "    v_simp_one_loc, \n",
-    "    \"+\"\n",
-    ")"
+    "// apply additive linear scaling\n",
+    "apply_adjustment_ls_add(\n",
+    "    v_ls_result,                // output vector\n",
+    "    v_obs_one_loc,              // reference data (control period)\n",
+    "    v_simh_one_loc,             // modeled data (control period)\n",
+    "    v_simp_one_loc              // modeled data (scenario period)\n",
+    ") "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "56814663-ba7f-4620-84b2-fb9ae5f5000a",
    "metadata": {},
    "outputs": [],
    "source": [
     "// apply quantile delta mapping\n",
     "apply_adjustment_qdm(\n",
-    "    v_qdm_result, \n",
-    "    v_obs_one_loc, \n",
-    "    v_simh_one_loc, \n",
-    "    v_simp_one_loc, \n",
-    "    \"+\",\n",
-    "    100\n",
-    ")"
+    "    v_qdm_result,               // output vector\n",
+    "    v_obs_one_loc,              // reference data (control period)\n",
+    "    v_simh_one_loc,             // modeled data (control period)\n",
+    "    v_simp_one_loc,             // modeled data (scenario period)\n",
+    "    \"+\",                        // kind of adjustment ('+' or '*')\n",
+    "    250                         // number of quantiles to respect\n",
+    ") "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "ad8fe08c-82bc-41ea-be4e-f1159ae168d3",
    "metadata": {},
    "outputs": [],
@@ -220,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "135e8dd1-5588-4f12-b3ba-ab90fbe8ff83",
    "metadata": {},
    "outputs": [
@@ -238,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "d83c6534-4223-4e05-bd76-e3f30fd1a90f",
    "metadata": {},
    "outputs": [
@@ -246,7 +245,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-2.49038"
+      "-2.49039"
      ]
     }
    ],
@@ -264,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "707cda33-35e9-47b9-890c-92126a6af512",
    "metadata": {},
    "outputs": [
@@ -282,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "b7942be1-3da1-4bc9-bf11-0560e0f98919",
    "metadata": {},
    "outputs": [
@@ -308,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "8bd00cbb-fc9d-4f42-be64-d7dc31c040bb",
    "metadata": {},
    "outputs": [
@@ -326,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "ee111c9e-a063-45c7-951a-7824de1e87af",
    "metadata": {},
    "outputs": [
@@ -621,9 +620,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "C++11 [conda env:clingenv]",
+   "display_name": "C++11",
    "language": "C++11",
-   "name": "conda-env-clingenv-xeus-cling-cpp11"
+   "name": "xeus-cling-cpp11"
   },
   "language_info": {
    "codemirror_mode": "text/x-c++src",

--- a/include/CMethods.hxx
+++ b/include/CMethods.hxx
@@ -31,7 +31,8 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
-typedef void (*CM_Func_ptr_scaling)(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario, std::string kind);
+typedef void (*CM_Func_ptr_scaling_add)(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario);
+typedef void (*CM_Func_ptr_scaling_mult)(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario, double max_scaling_factor);
 typedef void (*CM_Func_ptr_distribution)(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario, std::string kind, unsigned n_quantiles);
 
 class CMethods {
@@ -39,15 +40,18 @@ class CMethods {
     CMethods();
     ~CMethods();
 
-    static CM_Func_ptr_scaling get_cmethod_scaling(std::string method_name);
+    static CM_Func_ptr_scaling_add get_cmethod_scaling_add(std::string method_name);
+    static CM_Func_ptr_scaling_mult get_cmethod_scaling_mult(std::string method_name);
     static CM_Func_ptr_distribution get_cmethod_distribution(std::string method_name);
 
     static std::vector<std::string> scaling_method_names;
     static std::vector<std::string> distribution_method_names;
 
-    static void Linear_Scaling(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario, std::string kind);
-    static void Variance_Scaling(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario, std::string kind);
-    static void Delta_Method(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario, std::string kind);
+    static void Linear_Scaling_add(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario);
+    static void Linear_Scaling_mult(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario, double max_scaling_factor);
+    static void Variance_Scaling(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario);
+    static void Delta_Method_add(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario);
+    static void Delta_Method_mult(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario, double max_scaling_factor);
 
     static std::vector<double> get_xbins(std::vector<float>& a, std::vector<float>& b, unsigned n_quantiles, std::string kind);
     static void Quantile_Mapping(std::vector<float>& v_output, std::vector<float>& v_reference, std::vector<float>& v_control, std::vector<float>& v_scenario, std::string kind, unsigned n_quantiles);

--- a/include/MathUtils.hxx
+++ b/include/MathUtils.hxx
@@ -47,13 +47,21 @@ class MathUtils {
     static Func_two get_method_for_2_ds(std::string name);
 
     static double correlation_coefficient(std::vector<float>& x, std::vector<float>& y);
+
     static double rmse(std::vector<float>& x, std::vector<float>& y);
     static double mbe(std::vector<float>& x, std::vector<float>& y);
+
     static double ioa(std::vector<float>& x, std::vector<float>& y);
+
     static double sd(std::vector<float>& x);
     static double variance(std::vector<float>& x);
+
     static double mean(std::vector<float>& a);
     static double mean(std::vector<double>& a);
+
+    static float median(std::vector<float>& a);
+    static double median(std::vector<double>& a);
+
     static double lerp(double a, double b, double x);
 
     static std::vector<int> get_pdf(std::vector<float>& arr, std::vector<double>& bins);

--- a/src/MathUtils.cxx
+++ b/src/MathUtils.cxx
@@ -201,11 +201,24 @@ double MathUtils::mean(std::vector<float>& a) {
     for (unsigned i = 0; i < a.size(); i++) sum += a[i];
     return sum / a.size();
 }
-
 double MathUtils::mean(std::vector<double>& a) {
     double sum = 0;
     for (unsigned i = 0; i < a.size(); i++) sum += a[i];
     return sum / a.size();
+}
+
+/** Median
+ *
+ * @param a 1D vector of floats/doubles to get the median from
+ */
+
+float MathUtils::median(std::vector<float>& a) {
+    std::sort(a.begin(), a.end());
+    return a[(int)(a.size() / 2)];
+}
+double MathUtils::median(std::vector<double>& a) {
+    std::sort(a.begin(), a.end());
+    return a[(int)(a.size() / 2)];
 }
 
 /**


### PR DESCRIPTION
When adjusting for example a ratio based variable like precipitation using the multiplicative linear scaling bias adjustment procedure, the scaling factor $\frac{\mu_{m}(Pr_{obs,h}(i))}{\mu_{m}(Pr_{sim,h}(i))}$ can become unrealistic high when for example there is no precipitation in the modeled time series, but high values in the observed data. 

A default value of 10 is now set as the maximum scaling factor, this can be changed using the --max-scaling-factor flag <value>.
